### PR TITLE
maj pol.scss

### DIFF
--- a/app/styles/_flags/pol.scss
+++ b/app/styles/_flags/pol.scss
@@ -8,5 +8,5 @@
   $red: #d22630;
   $white: #FFF;
 
-  @include two-lines($red, $white);
+  @include two-lines($white, $red);
 };


### PR DESCRIPTION
Great Work !

1- I propose to invert the colors since it is white above red :
I dont know if the ratio should also be 4/8 instead of 5/8 ?
https://en.wikipedia.org/wiki/Poland

It should also apply here : https://pixelastic.github.io/css-flags/

2- I have a question : for re-using the flags using smaller size because some flags are based on px (ex for great britain) could it rely on % of space instead of px ?
